### PR TITLE
Normalize README as text

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.md text diff


### PR DESCRIPTION
## Summary
- add a .gitattributes entry to ensure Markdown files are handled as text

## Testing
- git log --stat -1


------
https://chatgpt.com/codex/tasks/task_e_68cc4e393388833096949026c98f7ccf